### PR TITLE
Fix live-user lists for destroy

### DIFF
--- a/app/jobs/xuser_destroy_broadcast_job.rb
+++ b/app/jobs/xuser_destroy_broadcast_job.rb
@@ -1,0 +1,26 @@
+class XuserDestroyBroadcastJob < ApplicationJob
+  queue_as :default
+
+  def perform(subscription)
+    ActionCable.server.broadcast "xroom_channel_#{subscription.xroom_id}",
+      xuser_count: render_xuser_count(subscription),
+      xusers: render_xroom_user(subscription)
+  end
+  
+  
+  private
+    
+    def render_xuser_count(subscription)
+      Subscription.where(xroom_id: subscription.xroom_id).where.not(user_id: subscription.user_id).count
+    end
+    
+    def render_xroom_user(subscription)
+      ApplicationController.renderer.render(partial: 'xrooms/xroom_user',
+                                          locals: { xroom_users: xusers(subscription) })
+    end 
+    
+    def xusers(subscription)
+      subscriptions = Subscription.where(xroom_id: subscription.xroom_id).where.not(user_id: subscription.user_id)
+      subscriptions.map {|s| s.user}
+    end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,5 +3,5 @@ class Subscription < ApplicationRecord
   belongs_to :xroom
   validates_uniqueness_of :user_id, :scope => :xroom_id
   after_create_commit { XuserBroadcastJob.perform_later self }
-  after_destroy_commit { XuserBroadcastJob.perform_later self }
+  after_destroy_commit { XuserDestroyBroadcastJob.perform_later self }
 end

--- a/test/jobs/xuser_destroy_broadcast_job_test.rb
+++ b/test/jobs/xuser_destroy_broadcast_job_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class XuserDestroyBroadcastJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Subscriptionのdestroyの時のブロードキャスト処理のデバッグ