### PR TITLE
edit breadcrumb and Xmessage layout

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -65,12 +65,12 @@ a {
 
 ol.breadcrumb {
   background: transparent;
+  padding: 0;
   margin-bottom: 10px;
   
   li+li:before {
-    content: '>>';
-    font-size: 1rem;
-    vertical-align: middle;
+    content: '> ';
+    font-size: 1.8rem;
     color: $gray-light;
   }
   
@@ -1025,16 +1025,18 @@ li.xroom_item {
 
 .xroom_exp {
   display: inline-block;
-  width: 80%;
-  background-color: #ddd;
+  width: 100%;
+  padding: 3px;
+  background-color: #f3f3f3;
+  border: 1px solid #ddd;
   overflow-wrap: break-word;
 }
 
 .xroom_users {
   margin: 0 auto 20px;
-  width: 80%;
+  width: 100%;
   max-height: 200px;
-  background-color: #ddd;
+  background-color: #f3f3f3;
   overflow: scroll;
 }
 
@@ -1045,11 +1047,17 @@ li.xroom_item {
   margin-bottom: 5px;
   padding-left: 5px;
   padding-right: 5px;
+  border: 1px solid #ddd;
   display: inline-block;
 }
 
 .xmessage_sidebar {
+  padding: 10px 30px 20px 30px;
   background-color: #fff;
+  
+  #xuser_count {
+    display: inline;
+  }
 }
 
 section.xmessage_box {

--- a/app/views/long_term_goals/index.html.erb
+++ b/app/views/long_term_goals/index.html.erb
@@ -1,4 +1,12 @@
 <div class="row">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <% if current_user == @user %>
+        <li class="breadcrumb-item"><%= link_to "HOME", root_path %></li>
+      <% end %>
+      <li class="breadcrumb-item current"><%= link_to "長期目標リスト", user_long_term_goals_path(@user) %></li>
+    </ol>
+  </nav>
   <aside class="col-md-3 user-sidebar">
     <section class="user_info">
       <h1>
@@ -25,11 +33,6 @@
     <% else %>
       <div class="l-index">
     <% end %>
-        <nav aria-label="breadcrumb">
-          <ol class="breadcrumb">
-            <li class="breadcrumb-item current"><%= link_to "長期目標リスト", user_long_term_goals_path(@user) %></li>
-          </ol>
-        </nav>
         <%= render 'l_goal' %>
       </div>
   </div>

--- a/app/views/mid_term_goals/index.html.erb
+++ b/app/views/mid_term_goals/index.html.erb
@@ -1,4 +1,13 @@
 <div class="row">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <% if current_user == @user %>
+        <li class="breadcrumb-item"><%= link_to "HOME", root_path %></li>
+      <% end %>
+      <li class="breadcrumb-item"><%= link_to "長期目標リスト", user_long_term_goals_path(@user) %></li>
+      <li class="breadcrumb-item current"><%= link_to "中期目標リスト", long_term_goal_mid_term_goals_path(@long_term_goal) %></li>
+    </ol>
+  </nav>
   <aside class="col-md-3 user-sidebar">
     <section class="user_info">
       <h1>
@@ -18,19 +27,13 @@
   </aside>
   
   <div class="col-md-9">
-    <h1 class = "m-goal-head"><%= @long_term_goal.category %><span>|</span><%= @long_term_goal.content %></h1>
+    <h1 class = "m-goal-head"><%= @long_term_goal.category %><span> | </span><%= @long_term_goal.content %></h1>
     <% if current_user == @user %>
       <p class="create-m-goal"><%= link_to "＋", new_long_term_goal_mid_term_goal_path(@long_term_goal), remote: true %></p>
       <div class="table-sortable ui-sortable m-index"> <!-- これ消すと並び替えできなくなるので注意 -->
     <% else %>
       <div class="m-index">
     <% end %>
-        <nav aria-label="breadcrumb">
-          <ol class="breadcrumb">
-            <li class="breadcrumb-item"><%= link_to "長期目標リスト", user_long_term_goals_path(@user) %></li>
-            <li class="breadcrumb-item current"><%= link_to "中期目標リスト", long_term_goal_mid_term_goals_path(@long_term_goal) %></li>
-          </ol>
-        </nav>
         <%= render 'm_goal' %>
       </div>
   </div>

--- a/app/views/short_term_goals/index.html.erb
+++ b/app/views/short_term_goals/index.html.erb
@@ -1,4 +1,15 @@
+
 <div class="row">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <% if current_user == @user %>
+        <li class="breadcrumb-item"><%= link_to "HOME", root_path %></li>
+      <% end %>
+      <li class="breadcrumb-item"><%= link_to "長期目標リスト", user_long_term_goals_path(@user) %></li>
+      <li class="breadcrumb-item"><%= link_to "中期目標リスト", long_term_goal_mid_term_goals_path(@long_term_goal) %></li>
+      <li class="breadcrumb-item current"><%= link_to "短期目標リスト", mid_term_goal_short_term_goals_path(@mid_term_goal) %></li>
+    </ol>
+  </nav>
   <aside class="col-md-3 user-sidebar">
     <section class="user_info">
       <h1>
@@ -18,20 +29,13 @@
   </aside>
   
   <div class="col-md-9">
-    <h1 class = "s-goal-head"><%= @long_term_goal.content %><span>|</span><%= @mid_term_goal.content %></h1>
+    <h1 class = "s-goal-head"><%= @long_term_goal.content %><span> | </span><%= @mid_term_goal.content %></h1>
     <% if current_user == @user %>
       <p class="create-s-goal"><%= link_to "＋", new_mid_term_goal_short_term_goal_path(@mid_term_goal), remote: true %></p>
       <div class="table-sortable ui-sortable s-index"> <!-- これ消すと並び替えできなくなるので注意 -->
     <% else %>
       <div class="s-index">
     <% end %>
-        <nav aria-label="breadcrumb">
-          <ol class="breadcrumb">
-            <li class="breadcrumb-item"><%= link_to "長期目標リスト", user_long_term_goals_path(@user) %></li>
-            <li class="breadcrumb-item"><%= link_to "中期目標リスト", long_term_goal_mid_term_goals_path(@long_term_goal) %></li>
-            <li class="breadcrumb-item current"><%= link_to "短期目標リスト", mid_term_goal_short_term_goals_path(@mid_term_goal) %></li>
-          </ol>
-        </nav>
         <%= render 's_goal' %>
       </div>
   </div>

--- a/app/views/xrooms/_xroom.html.erb
+++ b/app/views/xrooms/_xroom.html.erb
@@ -8,7 +8,7 @@
     <% unless xroom.name.blank? %>
       <span class="xroom_name"><%= link_to xroom.name, xroom_path(xroom), data: {"turbolinks" => false} %></span>
     <% else %>
-      <span class="xroom_name">X Room<%= xroom.id %></span>
+      <span class="xroom_name"><%= link_to "X Room #{xroom.id}", xroom_path(xroom), data: {"turbolinks" => false} %></span>
     <% end %>
     </li>
     <li class="xroom_desc">

--- a/app/views/xrooms/show.html.erb
+++ b/app/views/xrooms/show.html.erb
@@ -1,13 +1,13 @@
 <div class="row">
-  <aside class="col-md-4 center">
+  <aside class="col-md-4">
     <%= link_to 'Xroom一覧へ', xrooms_path, class: 'xroom_link', data: {"turbolinks" => false} %>
     <section class="xmessage_sidebar">
       <h3 class="xroom_attr">カテゴリー</h2>
       <p class="xroom_exp xroom_category"><%= @xroom.category %></p>
       <h3 class="xroom_attr">概要</h2>
       <p class="xroom_exp xroom_description"><%= @xroom.description %> </p>
-      <h3 class="xroom_attr">リアルタイムユーザー<span id="xuser_count"><%= @xroom.user_count %></span>人</h3>
-      <ul class="xroom_users">
+      <h3 class="xroom_attr">リアルタイムユーザー: <span id="xuser_count"><%= @xroom.user_count %></span>人</h3>
+      <ul class="xroom_users xroom_exp">
         <%= render 'xroom_user', xroom_users: @xroom_users %>
       </ul>
     </section>


### PR DESCRIPTION
パンくずリストと、XRoomの中のレイアウトを調整しました。
ログイン中のユーザーと目標リストを作成したユーザーが同じ場合のみ、HOMEというパンくずリストを最初につけてます。